### PR TITLE
Ensure pytest 6 compatibility.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ Changelog
 5.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Ensure compatibility with ``pytest > 6.0``.
 
 
 5.1 (2020-07-06)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = src --instafail --cov-report=term --pep8 --doctest-glob='*.txt'
+addopts = src --instafail --cov-report=term --flake8 --doctest-glob='*.txt'

--- a/src/gocept/testdb/__init__.py
+++ b/src/gocept/testdb/__init__.py
@@ -1,2 +1,7 @@
 from gocept.testdb.postgres import PostgreSQL
 from gocept.testdb.mysql import MySQL
+
+__all__ = [
+    'PostgreSQL',
+    'MySQL',
+]

--- a/src/gocept/testdb/base.py
+++ b/src/gocept/testdb/base.py
@@ -1,3 +1,4 @@
+from sqlalchemy.exc import SQLAlchemyError
 import os
 import random
 import sqlalchemy
@@ -107,7 +108,7 @@ class Database(object):
             try:
                 engine.connect().execute('SELECT * from tmp_functest')
                 return True
-            except:
+            except SQLAlchemyError:
                 return False
         finally:
             engine.dispose()
@@ -119,7 +120,7 @@ class Database(object):
             try:
                 engine.connect()
                 return True
-            except:
+            except SQLAlchemyError:
                 return False
         finally:
             engine.dispose()

--- a/src/gocept/testdb/postgres.py
+++ b/src/gocept/testdb/postgres.py
@@ -36,7 +36,7 @@ class PostgreSQL(Database):
             except SystemExit as e:
                 try:
                     self.drop_db(self.db_template)
-                except:  # pragma: no cover
+                except BaseException:  # pragma: no cover
                     pass
                 raise e
             try:

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps = mock
        pytest-cache
        pytest-cov
        pytest-instafail
-       pytest-pep8
+       pytest-flake8
        gocept.testing
        psycopg2
        PyMySQL


### PR DESCRIPTION
pytest-pep8 is no longer maintained and succeeded by pytest-flake8.