### PR TITLE
Fix force PostgreSQL `drop_db`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 
 - Switch CI to GHA.
 
+- Fix PostgreSQL ``drop_db`` to be able to forcibly drop a data base with open
+  connections, even though there is no database with the same name as the user.
+
 
 5.1 (2020-07-06)
 ----------------

--- a/src/gocept/testdb/postgres.py
+++ b/src/gocept/testdb/postgres.py
@@ -137,5 +137,6 @@ class PostgreSQL(Database):
                 ("SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
                  "WHERE datname = '" + db_name + "'"),
             ]:
-                subprocess.call(self.login_args('psql', ['-c', command]))
+                subprocess.call(self.login_args('psql', [
+                    '--dbname=postgres', '-c', command]))
             assert 0 == subprocess.call(self.login_args('dropdb', [db_name]))


### PR DESCRIPTION
It now works even though there is no data base named like the user.