### PR TITLE
Fix GHA

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
         - ["3.9",   "py39"]
         - ["3.8",   "coverage"]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: ${{ matrix.config[1] }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
ubuntu-latest is now 22.04 which no longer has Py27 and Py36.