### PR TITLE
Restrict supported SQLALchemy to < 2.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       hooks:
           - id: autopep8
     - repo: https://github.com/PyCQA/isort
-      rev: 5.11.4
+      rev: 5.12.0
       hooks:
       - id: isort
         args: [--filter-files]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 5.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Restrict supported SQLALchemy to < 2.
 
 
 5.2 (2021-04-26)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     namespace_packages=['gocept'],
     install_requires=[
         'setuptools',
-        'SQLAlchemy >= 0.5.6',
+        'SQLAlchemy >= 0.5.6, < 2',
     ],
     extras_require=dict(
         test=tests_require),


### PR DESCRIPTION
Otherwise tests fail.

See also #35.