### PR TITLE
Sqlalchemy2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,11 +30,10 @@ jobs:
       matrix:
         config:
         # [Python version, tox env]
-        - ["2.7",   "py27"]
-        - ["3.6",   "py36"]
-        - ["3.7",   "py37"]
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]
+        - ["3.10",  "py310"]
+        - ["3.11",  "py311"]
         - ["3.8",   "coverage"]
 
     runs-on: ubuntu-20.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,24 +28,28 @@ jobs:
           - 5432:5432
     strategy:
       matrix:
-        config:
+        python_version:
         # [Python version, tox env]
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]
         - ["3.10",  "py310"]
         - ["3.11",  "py311"]
-        - ["3.8",   "coverage"]
+        sqlalchemy_version:
+        - "sqlalchemy12"
+        - "sqlalchemy13"
+        - "sqlalchemy14"
+        - "sqlalchemy2x"
 
     runs-on: ubuntu-20.04
-    name: ${{ matrix.config[1] }}
+    name: ${{ matrix.python_version[1] }}-${{ matrix.sqlalchemy_version }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
-        python-version: ${{ matrix.config[0] }}
+        python-version: ${{ matrix.python_version[0] }}
     - uses: mirromutth/mysql-action@v1.1
-      if: matrix.config[1] != 'flake8'
+      if: matrix.python_version[1] != 'flake8'
       with:
         mysql root password: TTI06Z80U875E39U
     - name: Setup PostgreSQL environment
@@ -53,7 +57,7 @@ jobs:
         echo "localhost:5432:*:postgres:P0sTGrE5*Pa55W0rt!" >> ~/.pgpass
         chmod 600 ~/.pgpass
     - name: Pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.*', 'tox.ini') }}
@@ -70,11 +74,17 @@ jobs:
         MYSQL_HOST: 127.0.0.1
         MYSQL_USER: root
         MYSQL_PASS: TTI06Z80U875E39U
-      run: tox -e ${{ matrix.config[1] }} -- -vv --timeout=60
+      run: tox -e ${{ matrix.python_version[1] }} -- -vv --timeout=60
     - name: Coverage
-      if: matrix.config[1] == 'coverage'
+      if: matrix.python_version[0] == '3.8' && matrix.sqlalchemy_version == 'sqlalchemy2x'
       run: |
+        tox -e coverage -- -vv --timeout=60
         pip install coveralls coverage-python-version
         coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        POSTGRES_HOST: localhost
+        POSTGRES_USER: postgres
+        MYSQL_HOST: 127.0.0.1
+        MYSQL_USER: root
+        MYSQL_PASS: TTI06Z80U875E39U

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Features
 
 - Support Python 3.10 and 3.11.
 
+- Support SQLAlchemy 2.x.
+
 5.2.1 (2023-03-16)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,18 @@
 Changelog
 =========
 
-5.3 (unreleased)
+6.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+Backwards incompatible changes
+++++++++++++++++++++++++++++++
 
+- Dropped support for Python 2.7, 3.6 and 3.7.
+
+Features
+++++++++
+
+- Support Python 3.10 and 3.11.
 
 5.2.1 (2023-03-16)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Backwards incompatible changes
 
 - Dropped support for Python 2.7, 3.6 and 3.7.
 
+- Dropped support for SQLAlchemy < 1.2.
+
 Features
 ++++++++
 

--- a/README.rst
+++ b/README.rst
@@ -4,4 +4,4 @@ gocept.testdb
 
 Creates and drops temporary databases for testing purposes.
 
-This package has been tested with Python 2.7, 3.6 up to 3.9.
+This package has been tested with Python 3.8, 3.9, 3.10 and 3.11.

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     namespace_packages=['gocept'],
     install_requires=[
         'setuptools',
-        'SQLAlchemy >= 0.5.6, < 2',
+        'SQLAlchemy >= 1.2, < 2',
     ],
     extras_require=dict(
         test=tests_require),

--- a/setup.py
+++ b/setup.py
@@ -53,13 +53,11 @@ License :: OSI Approved :: Zope Public License
 Natural Language :: English
 Operating System :: OS Independent
 Programming Language :: Python
-Programming Language :: Python :: 2
-Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.6
-Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
+Programming Language :: Python :: 3.11
 Programming Language :: Python :: Implementation :: CPython
 Topic :: Database
 Topic :: Software Development :: Testing

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     namespace_packages=['gocept'],
     install_requires=[
         'setuptools',
-        'SQLAlchemy >= 1.2, < 2',
+        'SQLAlchemy >= 1.2, < 3',
     ],
     extras_require=dict(
         test=tests_require),

--- a/src/gocept/testdb/README.rst
+++ b/src/gocept/testdb/README.rst
@@ -63,7 +63,7 @@ The database is marked as a testing database by creating a table called
 ``tmp_functest`` in it:
 
 >>> conn = engine.connect()
->>> ignore = conn.execute('SELECT * from tmp_functest')
+>>> ignore = conn.execute(sqlalchemy.text('SELECT * from tmp_functest'))
 
 The database object also offers convenience methods for determining the status
 of the database:
@@ -76,7 +76,7 @@ True
 If you passed a ``schema_path`` to the constructor, the SQL code in this file
 is executed, e. g. to set up tables:
 
->>> ignore = conn.execute('SELECT * from foo')
+>>> ignore = conn.execute(sqlalchemy.text('SELECT * from foo'))
 
 When done, simply drop the database:
 
@@ -110,8 +110,8 @@ You can use the following environment variables to customize the DSN:
 >>> db.create()
 >>> engine = sqlalchemy.create_engine(db.dsn)
 >>> conn = engine.connect()
->>> ignore = conn.execute('SELECT * from tmp_functest')
->>> ignore = conn.execute('SELECT * from foo')
+>>> ignore = conn.execute(sqlalchemy.text('SELECT * from tmp_functest'))
+>>> ignore = conn.execute(sqlalchemy.text('SELECT * from foo'))
 >>> conn.invalidate()
 >>> db.drop()
 

--- a/src/gocept/testdb/README.rst
+++ b/src/gocept/testdb/README.rst
@@ -62,8 +62,9 @@ The dbapi DSN can then be used to connect to the database:
 The database is marked as a testing database by creating a table called
 ``tmp_functest`` in it:
 
->>> conn = engine.connect()
->>> ignore = conn.execute(sqlalchemy.text('SELECT * from tmp_functest'))
+>>> with engine.connect() as conn:
+...     with conn.begin():
+...         ignore = conn.execute(sqlalchemy.text('SELECT * from tmp_functest'))
 
 The database object also offers convenience methods for determining the status
 of the database:
@@ -76,11 +77,13 @@ True
 If you passed a ``schema_path`` to the constructor, the SQL code in this file
 is executed, e. g. to set up tables:
 
->>> ignore = conn.execute(sqlalchemy.text('SELECT * from foo'))
+>>> with engine.connect() as conn:
+...     with conn.begin():
+...         ignore = conn.execute(sqlalchemy.text('SELECT * from foo'))
 
 When done, simply drop the database:
 
->>> conn.close()
+>>> engine.dispose()
 >>> db.drop()
 
 PostgreSQL

--- a/src/gocept/testdb/base.py
+++ b/src/gocept/testdb/base.py
@@ -100,7 +100,7 @@ class Database(object):
         table = sqlalchemy.Table(
             'tmp_functest', meta,
             sqlalchemy.Column('schema_mtime', sqlalchemy.Integer))
-        table.create()
+        table.create(bind=engine)
         engine.dispose()
 
     @property
@@ -108,7 +108,9 @@ class Database(object):
         engine = self.connect()
         try:
             try:
-                engine.connect().execute('SELECT * from tmp_functest')
+                engine.connect().execute(sqlalchemy.text(
+                    'SELECT * from tmp_functest'
+                ))
                 return True
             except SQLAlchemyError:
                 return False

--- a/src/gocept/testdb/base.py
+++ b/src/gocept/testdb/base.py
@@ -88,13 +88,13 @@ class Database(object):
         """
         raise NotImplementedError
 
-    def connect(self, db_name=None):
+    def create_engine(self, db_name=None):
         if db_name is None:
             db_name = self.db_name
         return sqlalchemy.create_engine(self.get_dsn(db_name))
 
     def mark_testing(self, db_name):
-        engine = self.connect(db_name)
+        engine = self.create_engine(db_name)
         meta = sqlalchemy.MetaData()
         meta.bind = engine
         table = sqlalchemy.Table(
@@ -105,12 +105,13 @@ class Database(object):
 
     @property
     def is_testing(self):
-        engine = self.connect()
+        engine = self.create_engine()
         try:
             try:
-                engine.connect().execute(sqlalchemy.text(
-                    'SELECT * from tmp_functest'
-                ))
+                with engine.begin() as conn:
+                    conn.execute(sqlalchemy.text(
+                        'SELECT * from tmp_functest'
+                    ))
                 return True
             except SQLAlchemyError:
                 return False
@@ -119,11 +120,11 @@ class Database(object):
 
     @property
     def exists(self):
-        engine = self.connect()
+        engine = self.create_engine()
         try:
             try:
-                engine.connect()
-                return True
+                with engine.connect():
+                    return True
             except SQLAlchemyError:
                 return False
         finally:

--- a/src/gocept/testdb/mysql.py
+++ b/src/gocept/testdb/mysql.py
@@ -1,14 +1,6 @@
 from .base import Database
+from subprocess import TimeoutExpired
 import subprocess
-import sys
-
-
-PY3 = sys.version_info > (3, )
-if PY3:
-    from subprocess import TimeoutExpired
-else:
-    class TimeoutExpired(Exception):
-        """TimeoutExpired was introduced in Python 3.3."""
 
 
 class MySQL(Database):
@@ -53,12 +45,9 @@ class MySQL(Database):
                 for line in raw_list.splitlines()[3:-1]]
 
     def drop_db(self, db_name):
-        kw = {}
-        if PY3:
-            kw['timeout'] = 10  # seconds
         try:
             assert 0 == subprocess.call(
                 self.login_args('mysqladmin', ['--force', 'drop', db_name]),
-                **kw)
+                timeout=10)
         except TimeoutExpired:  # pragma: no cover
             pass

--- a/src/gocept/testdb/testing.py
+++ b/src/gocept/testdb/testing.py
@@ -43,7 +43,7 @@ class TestCase(unittest.TestCase):
             f.write(content)
 
     def connect(self, db):
-        engine = db.connect()
+        engine = db.create_engine()
         return engine.connect()
 
     def execute(self, dsn, cmd, fetch=False):

--- a/src/gocept/testdb/testing.py
+++ b/src/gocept/testdb/testing.py
@@ -60,8 +60,7 @@ class TestCase(unittest.TestCase):
 
     def table_names(self, dsn):
         engine = sqlalchemy.create_engine(dsn)
-        conn = engine.connect()
-        result = engine.table_names(connection=conn)
-        conn.invalidate()
-        conn.close()
+        insp = sqlalchemy.inspect(engine)
+        result = insp.get_table_names()
+        engine.dispose()
         return result

--- a/src/gocept/testdb/testing.py
+++ b/src/gocept/testdb/testing.py
@@ -48,14 +48,11 @@ class TestCase(unittest.TestCase):
 
     def execute(self, dsn, cmd, fetch=False):
         engine = sqlalchemy.create_engine(dsn)
-        conn = engine.connect()
-        try:
-            result = conn.execute(cmd)
+        with engine.begin() as conn:
+            result = conn.execute(sqlalchemy.text(cmd))
             if fetch:
                 result = result.fetchall()
-        finally:
-            conn.invalidate()
-            conn.close()
+        engine.dispose()
         return result
 
     def table_names(self, dsn):

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ usedevelop = true
 passenv =
   MYSQL_*
   POSTGRES_*
+  SQLALCHEMY_WARN_20
 extras =
     test
 deps =
@@ -20,7 +21,7 @@ deps =
   sqlalchemy12: SQLAlchemy >= 1.2,  < 1.3
   sqlalchemy13: SQLAlchemy >= 1.3,  < 1.4
   sqlalchemy14: SQLAlchemy >= 1.4,  < 2
-commands = py.test []
+commands = py.test -W always::DeprecationWarning []
 
 [testenv:flake8]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
 envlist =
   flake8,
-  py27,
-  py36,
-  py37,
   py38,
   py39,
+  py310,
+  py311,
   coverage,
-minversion = 3.7
+minversion = 3.8
 
 [testenv]
 usedevelop = true
@@ -17,11 +16,9 @@ passenv =
 extras =
     test
 deps =
-  py27: PyMySQL < 1
   pytest
   pytest-instafail
-  py27: pytest-timeout < 2
-  !py27: pytest-timeout
+  pytest-timeout
   execnet > 1.4.0
 commands = py.test []
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ usedevelop = true
 passenv =
   MYSQL_*
   POSTGRES_*
-  SQLALCHEMY_WARN_20
 extras =
     test
 deps =
@@ -22,7 +21,7 @@ deps =
   sqlalchemy13: SQLAlchemy >= 1.3, < 1.4
   sqlalchemy14: SQLAlchemy >= 1.4, < 2
   sqlalchemy2x: SQLAlchemy >= 2,   < 3
-commands = py.test -W always::DeprecationWarning []
+commands = py.test []
 
 [testenv:flake8]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
   flake8,
-  py{38,39,310,311}-sqlalchemy{12,13,14},
+  py{38,39,310,311}-sqlalchemy{12,13,14,2x},
   coverage,
 minversion = 3.8
 
@@ -18,9 +18,10 @@ deps =
   pytest-instafail
   pytest-timeout
   execnet > 1.4.0
-  sqlalchemy12: SQLAlchemy >= 1.2,  < 1.3
-  sqlalchemy13: SQLAlchemy >= 1.3,  < 1.4
-  sqlalchemy14: SQLAlchemy >= 1.4,  < 2
+  sqlalchemy12: SQLAlchemy >= 1.2, < 1.3
+  sqlalchemy13: SQLAlchemy >= 1.3, < 1.4
+  sqlalchemy14: SQLAlchemy >= 1.4, < 2
+  sqlalchemy2x: SQLAlchemy >= 2,   < 3
 commands = py.test -W always::DeprecationWarning []
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,7 @@
 [tox]
 envlist =
   flake8,
-  py38,
-  py39,
-  py310,
-  py311,
+  py{38,39,310,311}-sqlalchemy{12,13,14},
   coverage,
 minversion = 3.8
 
@@ -20,6 +17,9 @@ deps =
   pytest-instafail
   pytest-timeout
   execnet > 1.4.0
+  sqlalchemy12: SQLAlchemy >= 1.2,  < 1.3
+  sqlalchemy13: SQLAlchemy >= 1.3,  < 1.4
+  sqlalchemy14: SQLAlchemy >= 1.4,  < 2
 commands = py.test []
 
 [testenv:flake8]


### PR DESCRIPTION
Resolves #35.

I updated tox so that tests are run for multiple versions of SQLAlchemy.

SQLAlchemy 2.x drops support for Python 2.7. I went further and dropped support for 3.6 and 3.7 as well, since these are EoL. Potentially these could still be supported, I haven't tried testing them.

I also added support for Python 3.10 and 3.11, which implied dropping support for SQLAlchemy before 1.2. This could potentially be split into a different PR if needed.